### PR TITLE
Added public methods of HTTPService to interface

### DIFF
--- a/src/hex/service/stateless/http/IHTTPService.hx
+++ b/src/hex/service/stateless/http/IHTTPService.hx
@@ -13,7 +13,8 @@ interface IHTTPService extends IAsyncStatelessService
 	var method( get, null ) : HTTPRequestMethod;
 	var dataFormat( get, null ) : String;
 	var timeout( get, null ) : UInt;
-	
-	function addHeader( header : HTTPRequestHeader ) : Void;
 	function setParameters( parameters : HTTPServiceParameters ) : Void;
+	function getParameters() : HTTPServiceParameters;
+	function addHeader( header : HTTPRequestHeader ) : Void;
+	function setURL( url : String ) : Void;
 }


### PR DESCRIPTION
We need them to access to objects methods when they were inherited from HTTPService and will be accessed by interface (var service:IHTTPService)
